### PR TITLE
Update component name.

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function handleStateChangeOnClient(stringClassNames) {
   document.body.className = stringClassNames || '';
 }
 
-function DocumentTitle(props){
+function BodyClassName(props){
   if (props.children) {
     return React.Children.only(props.children);
   } else {
@@ -24,12 +24,12 @@ function DocumentTitle(props){
   }
 }
 
-DocumentTitle.displayName = 'DocumentTitle';
-DocumentTitle.propTypes = {
+BodyClassName.displayName = 'BodyClassName';
+BodyClassName.propTypes = {
   className: PropTypes.string.isRequired
 };
 
 module.exports = withSideEffect(
   reducePropsToState,
   handleStateChangeOnClient
-)(DocumentTitle);
+)(BodyClassName);


### PR DESCRIPTION
This component will now display correctly in the react dev tools.

`DocumentTitle` => `BodyClassName`

This is how it displayed before:

![react-body-classname](https://user-images.githubusercontent.com/963921/27405341-0d9d32da-5686-11e7-8f0a-db4a78b80afc.png)


