### PR TITLE
don't erase existing body classnames

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,12 @@ var React = require('react');
 var withSideEffect = require('react-side-effect');
 var PropTypes = require('prop-types');
 
+let classNameCache = []
+
+function splitClassName(className) {
+  return className.split(/\s+/)
+}
+
 function reducePropsToState(propsList) {
   return propsList.map(function(props) {
     return props.className;
@@ -13,7 +19,26 @@ function reducePropsToState(propsList) {
 }
 
 function handleStateChangeOnClient(stringClassNames) {
-  document.body.className = stringClassNames || '';
+  // get current body class as array
+  let currentClassNames = splitClassName(document.body.className)
+  
+  // remove all past class names
+  for (let i = 0; i < classNameCache.length; i++) {
+    const idx = currentClassNames.indexOf(classNameCache[i]);
+    if (idx !== -1) {
+      currentClassNames.splice(idx, 1);
+    }
+  }
+  
+  // append all new ones
+  const newClassNames = splitClassName(stringClassNames);
+  currentClassNames = currentClassNames.concat(newClassNames);
+
+  // set body class name
+  document.body.className = currentClassNames.join(' ').trim();
+
+  // track which class names we added
+  classNameCache = newClassNames;
 }
 
 function BodyClassName(props){

--- a/test/browser.spec.js
+++ b/test/browser.spec.js
@@ -19,7 +19,15 @@ describe('BodyClassName (in a browser)', function () {
     expect(global.document.body.className).to.equal(className);
   });
 
+  it('does not erase existing body class names', function () {
+    global.document.body.className = 'testing'
+    var className = 'hello world';
+    var Component = enzyme.mount(React.createElement(BodyClassName, {className: className}));
+    expect(global.document.body.className).to.equal('testing hello world');
+  });
+
   it('supports nesting, gathering all classNames used', function (done) {
+    global.document.body.className = ''
     var called = false;
     var firstName = 'hello world';
     var secondName = 'foo bar';


### PR DESCRIPTION
I was having a problem with [reactstrap](http://reactstrap.github.io) where the `modal-open` class name it set on &lt;body&gt; was erased. This pull request tracks which classes have been added by ReactBodyClassname and preserves other classes set on &lt;body&gt;.