### PR TITLE
Persist existing body classnames

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,12 @@ var React = require('react');
 var withSideEffect = require('react-side-effect');
 var PropTypes = require('prop-types');
 
+function splitClassName(className) {
+  return className.split(/\s+/)
+}
+
 function reducePropsToState(propsList) {
-  return propsList.map(function(props) {
+  return propsList.map(function (props) {
     return props.className;
   }).filter(function (value, index, self) {
     return self.indexOf(value) === index;
@@ -13,7 +17,15 @@ function reducePropsToState(propsList) {
 }
 
 function handleStateChangeOnClient(stringClassNames) {
-  document.body.className = stringClassNames || '';
+  var currentClassNames = splitClassName(document.body.className).filter(
+    function (className) {
+      return BodyClassName.cache.indexOf(className) === -1
+    });
+
+  var newClassNames = splitClassName(stringClassNames);
+
+  BodyClassName.cache = newClassNames;
+  document.body.className = currentClassNames.concat(newClassNames).join(' ').trim();
 }
 
 function BodyClassName(props){
@@ -25,6 +37,7 @@ function BodyClassName(props){
 }
 
 BodyClassName.displayName = 'BodyClassName';
+BodyClassName.cache = [];
 BodyClassName.propTypes = {
   className: PropTypes.string.isRequired
 };

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var withSideEffect = require('react-side-effect');
 var PropTypes = require('prop-types');
 
 function splitClassName(className) {
-  return className.split(/\s+/)
+  return className.split(/\s+/);
 }
 
 function reducePropsToState(propsList) {
@@ -19,7 +19,7 @@ function reducePropsToState(propsList) {
 function handleStateChangeOnClient(stringClassNames) {
   var currentClassNames = splitClassName(document.body.className).filter(
     function (className) {
-      return BodyClassName.cache.indexOf(className) === -1
+      return BodyClassName.cache.indexOf(className) === -1;
     });
 
   var newClassNames = splitClassName(stringClassNames);

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ function splitClassName(className) {
 }
 
 function reducePropsToState(propsList) {
-  return propsList.map(function (props) {
+  return propsList.map(function(props) {
     return props.className;
   }).filter(function (value, index, self) {
     return self.indexOf(value) === index;

--- a/test/browser.spec.js
+++ b/test/browser.spec.js
@@ -2,21 +2,29 @@
 /*global global, describe, it, afterEach, before, after */
 'use strict';
 var expect = require('expect.js'),
-    enzyme = require('enzyme'),
-    React = require('react'),
-    ReactDOM = require('react-dom'),
-    BodyClassName = require('../'),
-    jsdom = require('jsdom').jsdom;
+  enzyme = require('enzyme'),
+  React = require('react'),
+  ReactDOM = require('react-dom'),
+  BodyClassName = require('../'),
+  jsdom = require('jsdom').jsdom;
 
 describe('BodyClassName (in a browser)', function () {
   global.beforeEach(function () {
     BodyClassName.canUseDOM = true;
+    global.document.body.className = ''
   });
 
   it('changes the document body class name on mount', function () {
     var className = 'hello world';
     var Component = enzyme.mount(React.createElement(BodyClassName, {className: className}));
     expect(global.document.body.className).to.equal(className);
+  });
+
+  it('does not erase existing body class names', function () {
+    global.document.body.className = 'testing'
+    var className = 'hello world';
+    var Component = enzyme.mount(React.createElement(BodyClassName, { className: className }));
+    expect(global.document.body.className).to.equal('testing hello world');
   });
 
   it('supports nesting, gathering all classNames used', function (done) {

--- a/test/browser.spec.js
+++ b/test/browser.spec.js
@@ -27,6 +27,13 @@ describe('BodyClassName (in a browser)', function () {
     expect(global.document.body.className).to.equal('testing hello world');
   });
 
+  it('does not erase and or duplicate existing body class names', function () {
+    global.document.body.className = 'testing hello'
+    var className = 'hello world';
+    var Component = enzyme.mount(React.createElement(BodyClassName, { className: className }));
+    expect(global.document.body.className).to.equal('testing hello world');
+  });
+
   it('supports nesting, gathering all classNames used', function (done) {
     var called = false;
     var firstName = 'hello world';

--- a/test/browser.spec.js
+++ b/test/browser.spec.js
@@ -2,16 +2,16 @@
 /*global global, describe, it, afterEach, before, after */
 'use strict';
 var expect = require('expect.js'),
-  enzyme = require('enzyme'),
-  React = require('react'),
-  ReactDOM = require('react-dom'),
-  BodyClassName = require('../'),
-  jsdom = require('jsdom').jsdom;
+    enzyme = require('enzyme'),
+    React = require('react'),
+    ReactDOM = require('react-dom'),
+    BodyClassName = require('../'),
+    jsdom = require('jsdom').jsdom;
 
 describe('BodyClassName (in a browser)', function () {
   global.beforeEach(function () {
     BodyClassName.canUseDOM = true;
-    global.document.body.className = ''
+    global.document.body.className = '';
   });
 
   it('changes the document body class name on mount', function () {


### PR DESCRIPTION
I've took @mikhuang's implementation from https://github.com/iest/react-body-classname/pull/6 and applied @iest's feedback.

This PR fixes the issue that manually added classes to the body element got erased, as soon as the `handleStateChangeOnClient` function was called.

## Tasks done
- [x] updated `handleStateChangeOnClient` function
- [x] added test to ensure that no class gets duplicated
