### PR TITLE
Allow usage of react-side-effect 2.x along with 1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
   },
   "dependencies": {
     "prop-types": "^15.5.6",
-    "react-side-effect": "^1.1.0"
+    "react-side-effect": "^1.1.0 || ^2.1.0"
   }
 }


### PR DESCRIPTION
This fixes react 16.9 warnings, but allows users with older react (pre 16.3) to keep using the 1.x version since there are not api changes in `react-side-effect`